### PR TITLE
UX: Add sidebar support

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,6 +1,7 @@
 @import "variables";
 @import "topic";
 @import "topic-list";
+@import "sidebar";
 
 // General
 .btn {

--- a/scss/sidebar.scss
+++ b/scss/sidebar.scss
@@ -1,0 +1,17 @@
+.header-sidebar-toggle {
+  button.widget-button {
+    border-radius: 0.5rem;
+    transition: border-radius 0.2s;
+    .d-icon {
+      color: var(--header_primary);
+      font-size: 1em;
+    }
+    &:hover {
+      border-radius: 50%;
+      background-color: var(--tertiary);
+      .d-icon {
+        color: var(--light-accent);
+      }
+    }
+  }
+}

--- a/scss/sidebar.scss
+++ b/scss/sidebar.scss
@@ -15,3 +15,28 @@
     }
   }
 }
+
+.sidebar-wrapper {
+  background: transparent;
+
+  .sidebar-section-header-text {
+    font-size: 0.75rem;
+    letter-spacing: 0.03em;
+  }
+
+  .sidebar-footer-wrapper {
+    background: none;
+    .desktop-view & {
+      .sidebar-footer-container {
+        background: none;
+        &:before {
+          background: linear-gradient(
+            to bottom,
+            transparent,
+            rgba(var(--secondary-rgb), 1)
+          );
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support for Discourse's new sidebar.

Not many changes necessary, quite simple:
- [X] Fix sidebar toggle icon
- [X] Remove sidebar background color
- [X] Match titles in sidebar with Zeronoise title style

Before:
<img width="1512" alt="Screen Shot 2022-08-30 at 2 58 08 PM" src="https://user-images.githubusercontent.com/30090424/187551210-37fd88a4-9971-46fb-b4bd-fdbd19e404fb.png">

After:
<img width="1512" alt="Screen Shot 2022-08-30 at 3 20 59 PM" src="https://user-images.githubusercontent.com/30090424/187553875-d498491a-007c-491d-92b8-c9d4f0c635a3.png">
