### PR TITLE
UX: avoid keyboard covering content on android

### DIFF
--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -1,3 +1,8 @@
+body {
+  // avoids an issue where the virtual keyboard covers content on Android
+  padding-bottom: env(keyboard-inset-height, 0);
+}
+
 .container {
   &.posts {
     background-color: var(--main-background);
@@ -130,3 +135,4 @@
 .list-controls .btn {
   top: 0;
 }
+

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -135,4 +135,3 @@ body {
 .list-controls .btn {
   top: 0;
 }
-


### PR DESCRIPTION
This prevents the virtual keyboard from covering page content by adding the height of the keyboard as bottom padding on the page. 