### PR TITLE
DEV: update deprecated icon name in stylesheet

### DIFF
--- a/scss/topic.scss
+++ b/scss/topic.scss
@@ -84,7 +84,7 @@ aside.onebox {
   .d-icon {
     width: 0.75rem;
   }
-  .d-icon-unlock-alt {
+  .d-icon-unlock-keyhole {
     color: var(--primary);
   }
 }


### PR DESCRIPTION
This PR updates deprecated Font Awesome icon names in the stylesheet. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.